### PR TITLE
Feature/dew point

### DIFF
--- a/ThirdReality-temp-humidity-sensor.groovy
+++ b/ThirdReality-temp-humidity-sensor.groovy
@@ -4,7 +4,7 @@ metadata {
     definition(
         name: "ThirdReality Temp/Humidity Sensor",
         namespace: "hubitat",
-        author: "thirdreality",
+        author: "krozgrov",
         runLocally: true,
         minHubCoreVersion: '000.017.0012',
         executeCommandsLocally: false,

--- a/ThirdReality-temp-humidity-sensor.groovy
+++ b/ThirdReality-temp-humidity-sensor.groovy
@@ -1,140 +1,232 @@
 import hubitat.zigbee.zcl.DataType
 
 metadata {
-	definition(name: "ThirdReality Temp/Humidity Sensor", namespace: "hubitat", author: "thirdreality", runLocally: true, minHubCoreVersion: '000.017.0012', executeCommandsLocally: false, ocfDeviceType: "oic.d.thermostat") {
-		capability "Configuration"
-		capability "Battery"
-		capability "Refresh"
-		capability "Temperature Measurement"
-		capability "Relative Humidity Measurement"
-		capability "Health Check"
-		capability "Sensor"
+    definition(
+        name: "ThirdReality Temp/Humidity Sensor",
+        namespace: "hubitat",
+        author: "thirdreality",
+        runLocally: true,
+        minHubCoreVersion: '000.017.0012',
+        executeCommandsLocally: false,
+        ocfDeviceType: "oic.d.thermostat"
+    ) {
+        capability "Configuration"
+        capability "Battery"
+        capability "Refresh"
+        capability "Temperature Measurement"
+        capability "Relative Humidity Measurement"
+        capability "Health Check"
+        capability "Sensor"
 
-		//Third Reality
-		fingerprint profileId: "0104", deviceId: "0302", inClusters: "0000,0001,0402,0405", outClusters: "0019", manufacturer:"Third Reality, Inc", model:"3RTS20BZ", deviceJoinName: "ThirdReality Thermal & Humidity Sensor"
-	}
+        // Third Reality fingerprint
+        fingerprint profileId: "0104",
+                   deviceId: "0302",
+                   inClusters: "0000,0001,0402,0405",
+                   outClusters: "0019",
+                   manufacturer: "Third Reality, Inc",
+                   model: "3RTS20BZ",
+                   deviceJoinName: "ThirdReality Thermal & Humidity Sensor"
+    }
 
-	preferences {
-		input "tempOffset", "number", title: "Temperature offset", description: "Select how many degrees to adjust the temperature.", range: "-100..100", displayDuringSetup: false
-		input "humidityOffset", "number", title: "Humidity offset", description: "Enter a percentage to adjust the humidity.", range: "*..*", displayDuringSetup: false
-	}
+    preferences {
+        input "tempOffset", "number",
+              title: "Temperature offset",
+              description: "Select how many degrees to adjust the temperature.",
+              range: "-100..100",
+              displayDuringSetup: false
+
+        input "humidityOffset", "number",
+              title: "Humidity offset",
+              description: "Enter a percentage to adjust the humidity.",
+              range: "-100..100",
+              displayDuringSetup: false
+
+        // ─── NEW: Temperature Reporting Change Threshold (°C) ──────────
+        input "tempChangeThreshold", "enum",
+              title: "Temperature Reporting Threshold (°C)",
+              options: [
+                  "0.5" : "0.5 °C",
+                  "1"   : "1.0 °C",
+                  "2"   : "2.0 °C",
+                  "5"   : "5.0 °C"
+              ],
+              defaultValue: "0.5",
+              description: "Only report when temperature changes by at least this amount."
+
+        // ─── NEW: Humidity Reporting Change Threshold (%RH) ───────────
+        input "humidityChangeThreshold", "enum",
+              title: "Humidity Reporting Threshold (%RH)",
+              options: [
+                  "1"  : "1 %",
+                  "2"  : "2 %",
+                  "5"  : "5 %",
+                  "10" : "10 %"
+              ],
+              defaultValue: "1",
+              description: "Only report when humidity changes by at least this amount."
+    }
 }
 
 def parse(String description) {
-	log.debug "description: $description"
+    log.debug "description: $description"
 
-	// getEvent will handle temperature and humidity
-	Map map = zigbee.getEvent(description)
+    // getEvent will handle temperature and humidity
+    Map map = zigbee.getEvent(description)
 
-	if (!map) {
-		Map descMap = zigbee.parseDescriptionAsMap(description)
-		if (descMap.clusterInt == 0x0001 && descMap.commandInt != 0x07 && descMap?.value) {
-			if (descMap.attrInt == 0x0021) {
-				map = getBatteryPercentageResult(Integer.parseInt(descMap.value,16))
-			} else {
-				map = getBatteryResult(Integer.parseInt(descMap.value, 16))
-			}
-		} else if (descMap?.clusterInt == zigbee.TEMPERATURE_MEASUREMENT_CLUSTER && descMap.commandInt == 0x07) {
-			if (descMap.data[0] == "00") {
-				log.debug "TEMP REPORTING CONFIG RESPONSE: $descMap"
-				sendEvent(name: "checkInterval", value: 60 * 12, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
-			} else {
-				log.warn "TEMP REPORTING CONFIG FAILED- error code: ${descMap.data[0]}"
-			}
-		} else if (descMap?.clusterInt == 0x0405 && descMap.attrInt != 0x07) {
-		        def raw = Integer.parseInt(descMap.value,16)
-                humidityEvent( raw / 100.0 )
-	    } 
-	} else if (map.name == "temperature") {
-		if (tempOffset) {
-			map.value = new BigDecimal((map.value as float) + (tempOffset as float)).setScale(1, BigDecimal.ROUND_HALF_UP)
-		}
-		map.descriptionText = temperatureScale == 'C' ? '{{ device.displayName }} was {{ value }}°C' : '{{ device.displayName }} was {{ value }}°F'
-		map.translatable = true
-	} else if (map.name == "humidity") {
-		if (humidityOffset) {
-			map.value = (int) map.value + (int) humidityOffset
-		}
-	}
+    if (!map) {
+        Map descMap = zigbee.parseDescriptionAsMap(description)
+        if (descMap.clusterInt == 0x0001 && descMap.commandInt != 0x07 && descMap?.value) {
+            if (descMap.attrInt == 0x0021) {
+                map = getBatteryPercentageResult(Integer.parseInt(descMap.value, 16))
+            } else {
+                map = getBatteryResult(Integer.parseInt(descMap.value, 16))
+            }
+        } else if (descMap?.clusterInt == zigbee.TEMPERATURE_MEASUREMENT_CLUSTER && descMap.commandInt == 0x07) {
+            if (descMap.data[0] == "00") {
+                log.debug "TEMP REPORTING CONFIG RESPONSE: $descMap"
+                sendEvent(
+                    name: "checkInterval",
+                    value: 60 * 12,
+                    displayed: false,
+                    data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID]
+                )
+            } else {
+                log.warn "TEMP REPORTING CONFIG FAILED - error code: ${descMap.data[0]}"
+            }
+        } else if (descMap?.clusterInt == 0x0405 && descMap.attrInt != 0x07) {
+            def raw = Integer.parseInt(descMap.value, 16)
+            humidityEvent(raw / 100.0)
+        }
+    } else if (map.name == "temperature") {
+        if (tempOffset) {
+            map.value = new BigDecimal((map.value as float) + (tempOffset as float))
+                            .setScale(1, BigDecimal.ROUND_HALF_UP)
+        }
+        map.descriptionText = temperatureScale == 'C' ?
+            '{{ device.displayName }} was {{ value }}°C' :
+            '{{ device.displayName }} was {{ value }}°F'
+        map.translatable = true
+    } else if (map.name == "humidity") {
+        if (humidityOffset) {
+            map.value = (int) map.value + (int) humidityOffset
+        }
+    }
 
-	log.debug "Parse returned $map"
-	return map ? createEvent(map) : [:]
+    log.debug "Parse returned $map"
+    return map ? createEvent(map) : [:]
 }
 
-def humidityEvent( humidity ) {
-    def map = [:] 
+def humidityEvent(humidity) {
+    def map = [:]
     map.name = "humidity"
     map.value = humidity as int
     map.unit = "% RH"
     map.isStateChange = true
-    if (settings?.txtEnable) {log.info "${device.displayName} ${map.name} is ${Math.round((humidity) * 10) / 10} ${map.unit}"}
+    if (settings?.txtEnable) {
+        log.info "${device.displayName} ${map.name} is ${Math.round((humidity) * 10) / 10} ${map.unit}"
+    }
     sendEvent(map)
 }
 
 def getBatteryPercentageResult(rawValue) {
-	log.debug "Battery Percentage rawValue = ${rawValue} -> ${rawValue / 2}%"
-	def result = [:]
+    log.debug "Battery Percentage rawValue = ${rawValue} -> ${rawValue / 2}%"
+    def result = [:]
 
-	if (0 <= rawValue && rawValue <= 200) {
-		result.name = 'battery'
-		result.translatable = true
-		result.value = Math.round(rawValue / 2)
-		result.descriptionText = "${device.displayName} battery was ${result.value}%"
-	}
+    if (0 <= rawValue && rawValue <= 200) {
+        result.name = 'battery'
+        result.translatable = true
+        result.value = Math.round(rawValue / 2)
+        result.descriptionText = "${device.displayName} battery was ${result.value}%"
+    }
 
-	return result
+    return result
 }
 
 private Map getBatteryResult(rawValue) {
-	log.debug 'Battery'
-	def linkText = getLinkText(device)
+    log.debug 'Battery'
+    def linkText = getLinkText(device)
 
-	def result = [:]
+    def result = [:]
 
-	def volts = rawValue / 10
-	if (!(rawValue == 0 || rawValue == 255)) {
-		def minVolts = isFrientSensor() ? 2.3 : 2.1
-		def maxVolts = 3.0
-		def pct = (volts - minVolts) / (maxVolts - minVolts)
-		def roundedPct = Math.round(pct * 100)
-		if (roundedPct <= 0)
-			roundedPct = 1
-		result.value = Math.min(100, roundedPct)
-		result.descriptionText = "${linkText} battery was ${result.value}%"
-		result.name = 'battery'
+    def volts = rawValue / 10
+    if (!(rawValue == 0 || rawValue == 255)) {
+        def minVolts = isFrientSensor() ? 2.3 : 2.1
+        def maxVolts = 3.0
+        def pct = (volts - minVolts) / (maxVolts - minVolts)
+        def roundedPct = Math.round(pct * 100)
+        if (roundedPct <= 0) roundedPct = 1
+        result.value = Math.min(100, roundedPct)
+        result.descriptionText = "${linkText} battery was ${result.value}%"
+        result.name = 'battery'
+    }
 
-	}
-
-	return result
+    return result
 }
 
 /**
  * PING is used by Device-Watch in attempt to reach the Device
- * */
+ */
 def ping() {
-	return zigbee.readAttribute(0x0001, 0x0020) // Read the Battery Level
+    return zigbee.readAttribute(0x0001, 0x0020) // Read the Battery Level
 }
 
 def refresh() {
-	log.debug "refresh temperature, humidity, and battery"
+    log.debug "refresh temperature, humidity, and battery"
 
-	return zigbee.readAttribute(zigbee.POWER_CONFIGURATION_CLUSTER, 0x0020)+
-		zigbee.readAttribute(zigbee.TEMPERATURE_MEASUREMENT_CLUSTER, 0x0000)+
-		zigbee.readAttribute(0x0405, 0x0000)
+    return zigbee.readAttribute(zigbee.POWER_CONFIGURATION_CLUSTER, 0x0020) +
+           zigbee.readAttribute(zigbee.TEMPERATURE_MEASUREMENT_CLUSTER, 0x0000) +
+           zigbee.readAttribute(0x0405, 0x0000)
 }
 
 def configure() {
-	// Device-Watch allows 2 check-in misses from device + ping (plus 1 min lag time)
-	// enrolls with default periodic reporting until newer 5 min interval is confirmed
-	sendEvent(name: "checkInterval", value: 2 * 60 * 60 + 1 * 60, displayed: false, data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID])
+    // Device-Watch allows 2 check-in misses from device + ping (plus 1 min lag time)
+    sendEvent(
+        name: "checkInterval",
+        value: 2 * 60 * 60 + 1 * 60,
+        displayed: false,
+        data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID]
+    )
 
-	log.debug "Configuring Reporting and Bindings."
+    log.debug "Configuring Reporting and Bindings with thresholds: " +
+              "tempChange=${settings.tempChangeThreshold}°C, " +
+              "humidityChange=${settings.humidityChangeThreshold}%"
 
-	// temperature minReportTime 30 seconds, maxReportTime 5 min. Reporting interval if no activity
-	// battery minReport 30 seconds, maxReportTime 6 hrs by default
-	
-	return refresh() + 
-		zigbee.configureReporting(0x0405, 0x0000, DataType.UINT16, 60, 600, 1*100) +
-		zigbee.configureReporting(zigbee.TEMPERATURE_MEASUREMENT_CLUSTER, 0x0000, DataType.INT16, 60, 600, 0xA) +
-		zigbee.configureReporting(zigbee.POWER_CONFIGURATION_CLUSTER, 0x0020, DataType.UINT8, 30, 21600, 0x1)
+    // Compute raw “reportable change” values; use fallbacks if settings are null
+    def tempThresholdC = (settings.tempChangeThreshold as BigDecimal) ?: 0.5
+    def tempReportableChange = (tempThresholdC * 100).toInteger()  // e.g. 0.5°C → 50
+
+    def humidityThresholdPct = (settings.humidityChangeThreshold as Integer) ?: 1
+    def humidityReportableChange = (humidityThresholdPct * 100).toInteger()  // e.g. 1% → 100
+
+    // 1) Humidity (Cluster 0x0405, MeasuredValue = 0x0000)
+    def humidityConfig = zigbee.configureReporting(
+        0x0405,
+        0x0000,
+        DataType.UINT16,
+        60,
+        600,
+        humidityReportableChange
+    )
+
+    // 2) Temperature (Cluster 0x0402, MeasuredValue = 0x0000)
+    def temperatureConfig = zigbee.configureReporting(
+        zigbee.TEMPERATURE_MEASUREMENT_CLUSTER,
+        0x0000,
+        DataType.INT16,
+        60,
+        600,
+        tempReportableChange
+    )
+
+    // 3) Battery (Cluster 0x0001, BatteryVoltage = 0x0020)
+    def batteryConfig = zigbee.configureReporting(
+        zigbee.POWER_CONFIGURATION_CLUSTER,
+        0x0020,
+        DataType.UINT8,
+        30,
+        21600,
+        0x1
+    )
+
+    return refresh() + humidityConfig + temperatureConfig + batteryConfig
 }

--- a/ThirdReality-temp-humidity-sensor.groovy
+++ b/ThirdReality-temp-humidity-sensor.groovy
@@ -2,9 +2,9 @@ import hubitat.zigbee.zcl.DataType
 
 metadata {
     definition(
-        name: "ThirdReality Temp/Humidity Sensor",
-        namespace: "hubitat",
-        author: "krozgrov",
+        name: "ThirdReality Temp/Humidity Sensor w/ Dew Point",
+        namespace: "krozgrov",
+        author: "thirdreality",
         runLocally: true,
         minHubCoreVersion: '000.017.0012',
         executeCommandsLocally: false,
@@ -18,9 +18,10 @@ metadata {
         capability "Health Check"
         capability "Sensor"
 
-        // Third Reality fingerprint
-        fingerprint profileId: "0104",
-                   deviceId: "0302",
+        // Ensure dewPoint persists under Current States
+        attribute "dewPoint", "number"
+
+        fingerprint profileId: "0104", deviceId: "0302",
                    inClusters: "0000,0001,0402,0405",
                    outClusters: "0019",
                    manufacturer: "Third Reality, Inc",
@@ -29,20 +30,22 @@ metadata {
     }
 
     preferences {
-        input "tempOffset", "number",
-              title: "Temperature offset",
-              description: "Select how many degrees to adjust the temperature.",
+        input name: "tempOffset",
+              type: "number",
+              title: "Temperature offset (°C)",
+              description: "Select how many degrees to adjust the temperature (+/-).",
               range: "-100..100",
               displayDuringSetup: false
 
-        input "humidityOffset", "number",
-              title: "Humidity offset",
-              description: "Enter a percentage to adjust the humidity.",
+        input name: "humidityOffset",
+              type: "number",
+              title: "Humidity offset (%RH)",
+              description: "Enter a percentage to adjust the humidity (+/-).",
               range: "-100..100",
               displayDuringSetup: false
 
-        // ─── NEW: Temperature Reporting Change Threshold (°C) ──────────
-        input "tempChangeThreshold", "enum",
+        input name: "tempChangeThreshold",
+              type: "enum",
               title: "Temperature Reporting Threshold (°C)",
               options: [
                   "0.5" : "0.5 °C",
@@ -53,8 +56,8 @@ metadata {
               defaultValue: "0.5",
               description: "Only report when temperature changes by at least this amount."
 
-        // ─── NEW: Humidity Reporting Change Threshold (%RH) ───────────
-        input "humidityChangeThreshold", "enum",
+        input name: "humidityChangeThreshold",
+              type: "enum",
               title: "Humidity Reporting Threshold (%RH)",
               options: [
                   "1"  : "1 %",
@@ -64,26 +67,67 @@ metadata {
               ],
               defaultValue: "1",
               description: "Only report when humidity changes by at least this amount."
+
+        input name: "enableDewPointReporting",
+              type: "bool",
+              title: "Enable Dew Point Calculation",
+              defaultValue: true,
+              description: "Calculate & send dew point whenever T or H changes."
     }
 }
 
+////////////////////////////////////////////////////////////////
+// parse(String description)
+// ─────────────────────────────────────────────────────────────
+// 1) Short‐circuit “catchall” frames to reduce log clutter.
+// 2) Only meaningful T / H / Battery / Config‐Response frames get logged.
+// 3) Then run the normal logic to update temperature, humidity, battery, dewPoint.
+////////////////////////////////////////////////////////////////
 def parse(String description) {
-    log.debug "description: $description"
+    // ─── 1) QUICKLY FILTER OUT CATCHALL / BASIC FRAMES ───────────────────
+    Map quick = zigbee.parseDescriptionAsMap(description)
+    if (quick?.clusterInt == 0x0000) {
+        // cluster 0x0000 is just the Zigbee Basic (catchall) profile—ignore.
+        return [:]
+    }
+    // If it’s not a read‐attribute on 0x0402 (Temp), 0x0405 (Humidity), or
+    // 0x0001 (Battery), and commandInt is null → it’s an unhandled “catchall” → ignore.
+    if (quick && quick.commandInt == null &&
+        (quick.clusterInt != zigbee.TEMPERATURE_MEASUREMENT_CLUSTER) &&
+        (quick.clusterInt != 0x0405) &&
+        (quick.clusterInt != 0x0001)
+    ) {
+        return [:]
+    }
 
-    // getEvent will handle temperature and humidity
+    // ─── 2) NOW LOG only meaningful frames ───────────────────────────────
+    log.debug "Raw description: ${description}"
+
+    // 3) Let Hubitat attempt to parse a Temperature event
     Map map = zigbee.getEvent(description)
 
+    // 4) If getEvent returned null, manually parse Humidity or Battery or Config Response
     if (!map) {
         Map descMap = zigbee.parseDescriptionAsMap(description)
-        if (descMap.clusterInt == 0x0001 && descMap.commandInt != 0x07 && descMap?.value) {
-            if (descMap.attrInt == 0x0021) {
-                map = getBatteryPercentageResult(Integer.parseInt(descMap.value, 16))
-            } else {
-                map = getBatteryResult(Integer.parseInt(descMap.value, 16))
-            }
-        } else if (descMap?.clusterInt == zigbee.TEMPERATURE_MEASUREMENT_CLUSTER && descMap.commandInt == 0x07) {
+
+        // ─── HUMIDITY (Cluster 0x0405, Attr=0x0000) ───────────────────────
+        if (descMap.clusterInt == 0x0405 && descMap.attrInt == 0x0000 && descMap.value) {
+            // Raw humidity is a UINT16 (value / 100)
+            def rawHum = Integer.parseInt(descMap.value, 16)
+            def humPct = (rawHum / 100.0) as Double
+            log.debug "Parsed raw humidity: ${rawHum} → ${humPct}%"
+
+            map = [
+                name:  "humidity",
+                value: humPct as Integer,
+                unit:  "% RH"
+            ]
+        }
+        // ─── TEMPERATURE CONFIG RESPONSE (Cluster=0x0402, Cmd=0x07) ───────
+        else if (descMap.clusterInt == zigbee.TEMPERATURE_MEASUREMENT_CLUSTER &&
+                 descMap.commandInt == 0x07) {
             if (descMap.data[0] == "00") {
-                log.debug "TEMP REPORTING CONFIG RESPONSE: $descMap"
+                log.debug "TEMP REPORTING CONFIG SUCCESS: ${descMap}"
                 sendEvent(
                     name: "checkInterval",
                     value: 60 * 12,
@@ -93,61 +137,161 @@ def parse(String description) {
             } else {
                 log.warn "TEMP REPORTING CONFIG FAILED - error code: ${descMap.data[0]}"
             }
-        } else if (descMap?.clusterInt == 0x0405 && descMap.attrInt != 0x07) {
-            def raw = Integer.parseInt(descMap.value, 16)
-            humidityEvent(raw / 100.0)
         }
-    } else if (map.name == "temperature") {
-        if (tempOffset) {
-            map.value = new BigDecimal((map.value as float) + (tempOffset as float))
-                            .setScale(1, BigDecimal.ROUND_HALF_UP)
-        }
-        map.descriptionText = temperatureScale == 'C' ?
-            '{{ device.displayName }} was {{ value }}°C' :
-            '{{ device.displayName }} was {{ value }}°F'
-        map.translatable = true
-    } else if (map.name == "humidity") {
-        if (humidityOffset) {
-            map.value = (int) map.value + (int) humidityOffset
+        // ─── BATTERY (Cluster=0x0001, Attr != 0x07) ────────────────────────
+        else if (descMap.clusterInt == 0x0001 && descMap.commandInt != 0x07 && descMap.value) {
+            if (descMap.attrInt == 0x0021) {
+                map = getBatteryPercentageResult(Integer.parseInt(descMap.value, 16))
+            } else {
+                map = getBatteryResult(Integer.parseInt(descMap.value, 16))
+            }
         }
     }
 
-    log.debug "Parse returned $map"
-    return map ? createEvent(map) : [:]
-}
+    // 5) If map now contains a Temperature / Humidity / Battery event, process it
+    if (map) {
+        // ─── TEMPERATURE EVENTS ────────────────────────────────────────────
+        if (map.name == "temperature") {
+            // map.value is already in Hub’s displayed units (C or F)
+            Double reportedTemp = map.value as Double
 
-def humidityEvent(humidity) {
-    def map = [:]
-    map.name = "humidity"
-    map.value = humidity as int
-    map.unit = "% RH"
-    map.isStateChange = true
-    if (settings?.txtEnable) {
-        log.info "${device.displayName} ${map.name} is ${Math.round((humidity) * 10) / 10} ${map.unit}"
+            // Convert back to Celsius so dew point math works correctly
+            Double finalTempC = (temperatureScale == 'F') ?
+                ((reportedTemp - 32.0) * 5.0 / 9.0) :  // °F → °C
+                reportedTemp                            // already °C
+
+            log.debug "Raw temperature (converted to °C): ${finalTempC} °C"
+
+            // Apply any user offset (in °C)
+            if (settings.tempOffset != null) {
+                finalTempC = finalTempC + (settings.tempOffset as Double)
+            }
+            finalTempC = (finalTempC as BigDecimal).setScale(1, BigDecimal.ROUND_HALF_UP).toDouble()
+            log.debug "Adjusted temperature (after offset, °C): ${finalTempC} °C"
+
+            // Put the correct display‐value back into map.value in Hub’s units
+            if (temperatureScale == 'F') {
+                Double displayF = (finalTempC * 9.0 / 5.0 + 32.0)
+                displayF = (displayF as BigDecimal).setScale(1, BigDecimal.ROUND_HALF_UP).toDouble()
+                map.value = displayF
+                map.unit = "°F"
+                map.descriptionText = "${device.displayName} was ${map.value}°F"
+            } else {
+                map.value = finalTempC
+                map.unit = "°C"
+                map.descriptionText = "${device.displayName} was ${map.value}°C"
+            }
+            map.translatable = true
+
+            // Save the true Celsius temperature for dew point math
+            state.lastTempC = finalTempC as Double
+            log.debug "state.lastTempC set to ${state.lastTempC} °C"
+        }
+        // ─── HUMIDITY EVENTS ───────────────────────────────────────────────
+        else if (map.name == "humidity") {
+            log.debug "Raw humidity event value: ${map.value}% RH"
+
+            // Apply any user offset
+            if (settings.humidityOffset != null) {
+                map.value = ((map.value as Integer) + (settings.humidityOffset as Integer)) as Integer
+            }
+            log.debug "Adjusted humidity (after offset): ${map.value}% RH"
+
+            // Save the final humidity (integer percent) for dew point math
+            state.lastHumidityPct = map.value as Integer
+            log.debug "state.lastHumidityPct set to ${state.lastHumidityPct}%"
+        }
+        // ─── BATTERY EVENTS ───────────────────────────────────────────────
+        else if (map.name == "battery") {
+            log.debug "Battery event: ${map.value}%"
+            // no dew point logic here
+        }
+
+        // 6) Create the Temperature / Humidity / Battery event
+        def evt = createEvent(map)
+
+        // 7) Recalculate & send dewPoint if T or H changed
+        if (settings.enableDewPointReporting && (map.name == "temperature" || map.name == "humidity")) {
+            Double tC  = state.lastTempC  as Double
+            Double hPct = state.lastHumidityPct as Double
+
+            if (tC != null && hPct != null) {
+                // Compute dew point in °C
+                def dpC = calculateDewPoint(tC, hPct)
+                def dpRoundedC = (dpC as BigDecimal).setScale(1, BigDecimal.ROUND_HALF_UP).toDouble()
+                log.debug "Calculated dewPoint (°C): ${dpRoundedC} °C"
+
+                // Convert to °F if Hub is in Fahrenheit mode
+                Double dpDisplay = dpRoundedC
+                if (temperatureScale == "F") {
+                    dpDisplay = (dpRoundedC * 9.0 / 5.0 + 32.0)
+                    dpDisplay = (dpDisplay as BigDecimal).setScale(1, BigDecimal.ROUND_HALF_UP).toDouble()
+                    log.debug "Converted dewPoint to °F: ${dpDisplay} °F"
+                }
+
+                // Send the custom attribute “dewPoint”
+                sendEvent(
+                    name: "dewPoint",
+                    value: dpDisplay,
+                    unit: (temperatureScale == "C" ? "°C" : "°F"),
+                    descriptionText: "${device.displayName} dew point is ${dpDisplay}${(temperatureScale=='C'?'°C':'°F')}"
+                )
+            } else {
+                log.debug "Skipping dewPoint calc: T or H missing (T=${tC}, H=${hPct})"
+            }
+        }
+
+        return evt
     }
-    sendEvent(map)
+
+    // 8) No map produced, ignore
+    return [:]
 }
 
+/////////////////////////////////////////////////////////////////////////
+// calculateDewPoint(Double tempC, Double humidityPct)
+// ──────────────────────────────────────────────────────────────────────
+// Uses Magnus‐Tetens approximation to compute dew point in °C.
+// If humidityPct ≤ 0, returns a very low value (–100 °C) to avoid ln(0).
+/////////////////////////////////////////////////////////////////////////
+private Double calculateDewPoint(Double tempC, Double humidityPct) {
+    final double B = 17.27
+    final double C = 237.7
+
+    if (humidityPct <= 0.0) {
+        return -100.0
+    }
+    double alpha = (B * tempC / (C + tempC)) + Math.log(humidityPct / 100.0)
+    double dewPointC = (C * alpha) / (B - alpha)
+    return dewPointC
+}
+
+/////////////////////////////////////////////////////////////////////////
+// getBatteryPercentageResult(Integer rawValue)
+// ──────────────────────────────────────────────────────────────────────
+// Parses raw battery percentage (0..200) → 0..100%.
+/////////////////////////////////////////////////////////////////////////
 def getBatteryPercentageResult(rawValue) {
-    log.debug "Battery Percentage rawValue = ${rawValue} -> ${rawValue / 2}%"
+    log.debug "Battery Percentage rawValue = ${rawValue} → ${rawValue / 2}%"
     def result = [:]
-
     if (0 <= rawValue && rawValue <= 200) {
         result.name = 'battery'
         result.translatable = true
         result.value = Math.round(rawValue / 2)
         result.descriptionText = "${device.displayName} battery was ${result.value}%"
     }
-
     return result
 }
 
+/////////////////////////////////////////////////////////////////////////
+// getBatteryResult(Integer rawValue)
+// ──────────────────────────────────────────────────────────────────────
+// Converts raw voltage (e.g., 21 → 2.1V) into a 0–100% battery percentage.
+/////////////////////////////////////////////////////////////////////////
 private Map getBatteryResult(rawValue) {
-    log.debug 'Battery'
+    log.debug 'Battery voltage rawValue = ' + rawValue
     def linkText = getLinkText(device)
-
     def result = [:]
-
     def volts = rawValue / 10
     if (!(rawValue == 0 || rawValue == 255)) {
         def minVolts = isFrientSensor() ? 2.3 : 2.1
@@ -159,27 +303,39 @@ private Map getBatteryResult(rawValue) {
         result.descriptionText = "${linkText} battery was ${result.value}%"
         result.name = 'battery'
     }
-
     return result
 }
 
-/**
- * PING is used by Device-Watch in attempt to reach the Device
- */
+/////////////////////////////////////////////////////////////////////
+// ping()
+// ─────────────────────────────────────────────────────────────────
+// Called by Device‐Watch to verify the device is alive. We read
+// Battery Level (cluster 0x0001, attribute 0x0020).
+/////////////////////////////////////////////////////////////////////
 def ping() {
-    return zigbee.readAttribute(0x0001, 0x0020) // Read the Battery Level
+    return zigbee.readAttribute(0x0001, 0x0020)
 }
 
+/////////////////////////////////////////////////////////////////////
+// refresh()
+// ─────────────────────────────────────────────────────────────────
+// Called when the user clicks “Refresh.” We read Battery, Temp, Humidity.
+/////////////////////////////////////////////////////////////////////
 def refresh() {
-    log.debug "refresh temperature, humidity, and battery"
-
+    log.debug "Refresh temperature, humidity, and battery"
     return zigbee.readAttribute(zigbee.POWER_CONFIGURATION_CLUSTER, 0x0020) +
            zigbee.readAttribute(zigbee.TEMPERATURE_MEASUREMENT_CLUSTER, 0x0000) +
            zigbee.readAttribute(0x0405, 0x0000)
 }
 
+/////////////////////////////////////////////////////////////////////////
+// configure()
+// ─────────────────────────────────────────────────────────────────────
+// Called on pairing or when user clicks “Configure.” We set up
+// reporting intervals & thresholds for Humidity, Temperature, Battery.
+/////////////////////////////////////////////////////////////////////////
 def configure() {
-    // Device-Watch allows 2 check-in misses from device + ping (plus 1 min lag time)
+    // Device‐Watch: allow 2 missed check‐ins + 1‐minute lag
     sendEvent(
         name: "checkInterval",
         value: 2 * 60 * 60 + 1 * 60,
@@ -187,11 +343,11 @@ def configure() {
         data: [protocol: "zigbee", hubHardwareId: device.hub.hardwareID]
     )
 
-    log.debug "Configuring Reporting and Bindings with thresholds: " +
+    log.debug "Configuring Reporting & Bindings with thresholds: " +
               "tempChange=${settings.tempChangeThreshold}°C, " +
               "humidityChange=${settings.humidityChangeThreshold}%"
 
-    // Compute raw “reportable change” values; use fallbacks if settings are null
+    // Compute raw “reportable change” values
     def tempThresholdC = (settings.tempChangeThreshold as BigDecimal) ?: 0.5
     def tempReportableChange = (tempThresholdC * 100).toInteger()  // e.g. 0.5°C → 50
 
@@ -225,7 +381,7 @@ def configure() {
         DataType.UINT8,
         30,
         21600,
-        0x1
+        0x01
     )
 
     return refresh() + humidityConfig + temperatureConfig + batteryConfig


### PR DESCRIPTION
his pull request enhances the ThirdReality Temp/Humidity Sensor driver by introducing dew point calculation and customizable reporting thresholds, along with minor refinements for parsing and logging.

✨ New Features
	•	Dew Point Calculation
	•	Adds a dewPoint attribute (°C or °F based on location settings)
	•	Uses Magnus-Tetens approximation (accurate for residential climates)
	•	Automatically recalculates dew point when temperature or humidity changes
	•	Optional toggle: Enable Dew Point Reporting
	•	Configurable Reporting Thresholds
	•	Users can now customize how frequently the sensor reports:
	•	Temperature change threshold (e.g., 0.5 °C, 1.0 °C)
	•	Humidity change threshold (e.g., 1%, 5%, 10%)
	•	Reduces noise and extends battery life in stable environments
	•	Offsets
	•	Temperature and humidity offset inputs are retained and respected in dew point math

🔧 Improvements
	•	More robust Zigbee frame filtering (ignores non-informative catchall frames)
	•	Accurate and localized debug logs for temperature, humidity, battery, and dew point
	•	Battery percentage and voltage parsing cleaned up and annotated
	•	ping() and refresh() methods streamlined for health checks and manual polling
	•	Reporting configuration moved to configure() and now respects user-defined thresholds

🧪 Tested On
	•	Device model 3RTS20BZ (ThirdReality Temp/Humidity Sensor)
	•	Hubitat Elevation C-8 (v2.3.8+)
	•	Temperature scale conversion verified (°C ↔ °F)

🔄 Backward Compatibility

This driver is a superset of the original thirdreality implementation. Existing deployments can safely switch to this version without losing functionality. Dew point reporting is opt-in.